### PR TITLE
Add json file parsing for action attributes

### DIFF
--- a/src/Graph/Action.h
+++ b/src/Graph/Action.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace Graph {	
+	struct ActionActor{
+	public:
+		float stimulation;
+		std::vector<std::string> requirements;
+		std::vector<int> strippingSlots;
+	};
+	struct ActionPerformer {
+	public:
+		std::unordered_map<std::string, float> floats;
+	};
+
+	struct ActionAttributes {
+	public:
+		ActionActor actor;
+		ActionActor target;
+		ActionPerformer performer;
+	};
+}

--- a/src/Graph/Action.h
+++ b/src/Graph/Action.h
@@ -6,16 +6,15 @@ namespace Graph {
 		float stimulation;
 		std::vector<std::string> requirements;
 		std::vector<int> strippingSlots;
-	};
-	struct ActionPerformer {
-	public:
+		std::unordered_map<std::string, int> ints;
 		std::unordered_map<std::string, float> floats;
+		std::unordered_map<std::string, std::string> strings;
 	};
 
 	struct ActionAttributes {
 	public:
 		ActionActor actor;
 		ActionActor target;
-		ActionPerformer performer;
+		ActionActor performer;
 	};
 }

--- a/src/Graph/LookupTable.cpp
+++ b/src/Graph/LookupTable.cpp
@@ -57,16 +57,27 @@ namespace Graph {
                 actor.strippingSlots.push_back(slot.get<int>());
             }
         }
-    };
-
-    void parsePerformer(json& json, ActionPerformer& performer) {
         if (json.contains("floats")) {
             auto& floats = json["floats"];
             for (json::iterator it = floats.begin(); it != floats.end(); it++) {
-                performer.floats.insert(std::make_pair(it.key(), it.value().get<float>()));
+                actor.floats.insert(std::make_pair(it.key(), it.value().get<float>()));
             }
         }
-    }
+
+        if (json.contains("ints")) {
+            auto& floats = json["ints"];
+            for (json::iterator it = floats.begin(); it != floats.end(); it++) {
+                actor.ints.insert(std::make_pair(it.key(), it.value().get<int>()));
+            }
+        }
+
+        if (json.contains("strings")) {
+            auto& floats = json["strings"];
+            for (json::iterator it = floats.begin(); it != floats.end(); it++) {
+                actor.strings.insert(std::make_pair(it.key(), it.value().get<std::string>()));
+            }
+        }
+    };
 
     void LookupTable::SetupActions(){        
     
@@ -83,6 +94,9 @@ namespace Graph {
                 attr.target = target;
             }
             if(json.contains("performer")){
+                Graph::ActionActor performer;
+                parseActor(json["performer"], performer);
+                attr.performer = performer;
             }
             actions.insert(std::make_pair(filename, attr));
         });

--- a/src/Graph/LookupTable.h
+++ b/src/Graph/LookupTable.h
@@ -12,9 +12,13 @@ namespace Graph{
 
         static bool SetNiTransfromInterface(SKEE::INiTransformInterface* nioInterface);
         static SKEE::INiTransformInterface* GetNiTransformInterface();
+
+        static void SetupActions();
+        static ActionAttributes* GetActionAttributesByType(std::string type);
     private:
         inline static std::unordered_map<std::string, Node*> nodes;
         inline static std::unordered_map<std::string, Node*> animationNodeTable;
+        inline static std::unordered_map<std::string, ActionAttributes> actions;
         
         inline static SKEE::INiTransformInterface* niTransformInterface;
     };

--- a/src/Graph/Node.h
+++ b/src/Graph/Node.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "Action.h"
 #include "Trait/FacialExpression.h"
 
 namespace Graph {
     struct Action {
     public:
         std::string type;
+        ActionAttributes* attributes;
         uint32_t actor;
         uint32_t target;
         uint32_t performer;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -103,6 +103,7 @@ SKSEPluginLoad(const LoadInterface* skse) {
 
     Patch::Install();
     Papyrus::Bind();
+    Graph::LookupTable::SetupActions();
     Papyrus::Build();
     Trait::TraitTable::setup();
 

--- a/src/Papyrus/PapyrusDatabase.h
+++ b/src/Papyrus/PapyrusDatabase.h
@@ -233,7 +233,7 @@ namespace PapyrusDatabase {
                     } else {
                         actionObj->performer = actor.as_int();
                     }
-
+                    actionObj->attributes = Graph::LookupTable::GetActionAttributesByType(actionObj->type);
                     node->actions.push_back(actionObj);
                 }
             }

--- a/src/Util/JsonFileLoader.h
+++ b/src/Util/JsonFileLoader.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace Util {
+
+	class JsonFileLoader {
+	public:
+		inline static void LoadFilesInFolder(std::string path, std::function<void(std::string, json)> callback) {
+			fs::path rootPath{ path };
+			if (!fs::exists(rootPath)) {
+				logger::warn("expression path ({}) does not exist", path);
+				return;
+			}
+			for (auto& file : fs::directory_iterator{ rootPath }) {
+				auto& path = file.path();
+				auto pathStr = path.string();
+				if (pathStr.ends_with(".json")) {
+					logger::info("parsing file {}", pathStr);
+					std::ifstream ifs(pathStr);
+					json json = json::parse(ifs, nullptr, false);
+
+					if (json.is_discarded()) {
+						logger::warn("file {} is malformed", pathStr);
+						continue;
+					}
+					callback(path.filename().replace_extension("").string(), json);
+					logger::info("parsed file {}", pathStr);
+				}
+			}
+		}
+	};
+}


### PR DESCRIPTION
Moved out the json parser into its own method so we can scan different folders
Attached a pointer on the current graph nodes so the attributes don't need to be replicated in memory (we could have this overriden manually on any given node potentially, but that can come later if we want it)